### PR TITLE
Fix passport install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ php artisan migrate --seed
 
 php artisan passport:keys --force
 
-** php artisan passport:install --force this will create migration files which is not needed **
+** php artisan passport:install --force   # this will create migration files which are not needed **
 
 ```
 


### PR DESCRIPTION
## Summary
- clarify the note about `php artisan passport:install` in README

## Testing
- `composer install --no-interaction` *(fails: composer not found)*
- `vendor/bin/phpunit --no-interaction` *(fails: vendor/bin/phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f78dad688323a31e72f193e3ba7f