### PR TITLE
Update README for passport install clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ php artisan migrate --seed
 
 php artisan passport:keys --force
 
-** php artisan passport:install --force   # this will create migration files which are not needed **
+**php artisan passport:install --force   # this will create migration files which are not needed**
 
 ```
 


### PR DESCRIPTION
## Summary
- clarify the Laravel Passport installation command in the README

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544c89af148323aed6ba8a71d4d62a